### PR TITLE
Update Vcl.DHTokenEngine.pas

### DIFF
--- a/Source/Vcl.DHTokenEngine.pas
+++ b/Source/Vcl.DHTokenEngine.pas
@@ -1858,6 +1858,8 @@ begin
       if BreakableChar then Inc(I) else
         if I=0 then I := Len+1;
 
+      if (Copy(Text, CurPos, 1) = '&') and (Copy(Text, I, 1) = ';') then Inc(I); // for &gt;&lt;  
+
       with AddToken<TDHToken_Word> do
       begin
         Word := TDzHTMLText.UnescapeHTMLToText(Copy(Text, CurPos, I-CurPos));


### PR DESCRIPTION
Incorrect show escaped text (&gt;&lt;)

Before changes:

<img width="361" height="121" alt="image" src="https://github.com/user-attachments/assets/0fa126c3-11f3-4f2a-96b6-7f92045ecd57" />

After changes:

<img width="361" height="119" alt="image" src="https://github.com/user-attachments/assets/1f718208-cbdd-43b6-ab33-473fdbfdd6dc" />

